### PR TITLE
Fix dev shell input on non-NixOS: set C.UTF-8 locale

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,15 @@
           # host-side HTTPS downloads (ISO, packer init, curl) would fail.
           SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 
+          # Give the Nix-provided bash/glibc a working UTF-8 locale. On a
+          # non-NixOS host, nixpkgs glibc can't resolve the system locale, so
+          # it falls back to C (ASCII) and readline byte-counts multibyte
+          # prompt glyphs -- the cursor math breaks and typed input appears to
+          # vanish (e.g. with a UTF-8 git prompt). C.UTF-8 is built into glibc
+          # and needs no locale archive, so it works everywhere.
+          LANG = "C.UTF-8";
+          LC_ALL = "C.UTF-8";
+
           shellHook = ''
             echo "vagrant-archlinux dev shell (build deps from Nix)"
             echo "  packer : $(packer version 2>/dev/null | head -n1)"


### PR DESCRIPTION
## Symptom

Inside `nix develop` on a non-NixOS host (Arch), typed characters stop appearing after the first command — it looks like the terminal lost echo. Reproducible: ssh in → `cd repo` → `nix develop` → first `ls` echoes, second one doesn't.

## Root cause (hypothesis to verify)

Not a lost `echo` (termios) and not the git prompt per se. It's a **locale problem in the Nix dev shell**:

- `nix develop` uses nixpkgs' own bash + glibc. On a non-NixOS host that glibc can't find the system locale definitions, so `setlocale` falls back to the `C` (ASCII) locale even when `LANG=…UTF-8` is set.
- In `C`, readline **byte-counts** the multibyte glyphs in the prompt (the UTF-8 git prompt uses `✔`/`➤`) instead of character-counting. Its column math breaks, so the redraw overwrites typed input — input is fine, the *rendering* is wrong.
- It surfaces after the first command because the prompt tool only installs the multibyte prompt on the next redraw.
- The normal shell (zsh + system glibc) resolves locales fine, so this only happens in `nix develop`.

## Fix

Set a UTF-8 locale in the dev shell:

```nix
LANG = "C.UTF-8";
LC_ALL = "C.UTF-8";
```

`C.UTF-8` is built into glibc and needs no locale archive, so it works on any host with zero extra closure. (If full locales like `en_US.UTF-8` are ever wanted, the alternative is `LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive"` — correct but ~200 MB.)

## How to verify on the host

Quick confirm in the *current* broken shell (blind-type):

```sh
export LC_ALL=C.UTF-8   # typing should start echoing again
```

Then with this branch:

```sh
git fetch origin && git checkout fix-devshell-locale
nix develop            # type `ls`, run it, type `ls` again — input should stay visible
```

Not built/tested here (per the usual: builds run on the user's server). `flake.nix` passes `nix-instantiate --parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)