### PR TITLE
Fix broken echo in nix develop: don't SIGPIPE packer in shellHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,15 @@
           SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 
           shellHook = ''
+            # First line only via `awk 'NR==1'`, NOT `head -n1`. `packer version`
+            # prints a second line (the "out of date" notice); `head -n1` closes
+            # the pipe after line 1, so packer is killed by SIGPIPE mid-write and
+            # never restores the terminal it had switched to raw mode -- which
+            # silently leaves `nix develop` with broken echo / line editing. `awk`
+            # reads to EOF, so packer (and qemu) exit cleanly and restore the tty.
             echo "vagrant-archlinux dev shell (build deps from Nix)"
-            echo "  packer : $(packer version 2>/dev/null | head -n1)"
-            echo "  qemu   : $(qemu-system-x86_64 --version 2>/dev/null | head -n1)"
+            echo "  packer : $(packer version 2>/dev/null | awk 'NR==1')"
+            echo "  qemu   : $(qemu-system-x86_64 --version 2>/dev/null | awk 'NR==1')"
             echo
             echo "  make init && make build         # VirtualBox/Vagrant box (uses system VirtualBox)"
             echo "  make init && make build-qemu    # QEMU qcow2 image"


### PR DESCRIPTION
## The bug

Inside `nix develop`, the terminal lost echo / line editing after the first command. After a long hunt (and ruling out the user's dotfiles, bash-git-prompt, locale, and direnv), a **faithful pty reproduction of the real `nix develop` interactive shell** bisected it to **our own `shellHook`**:

```sh
echo "  packer : $(packer version 2>/dev/null | head -n1)"
```

`packer version` prints **two** lines (version + an "out of date" notice). `head -n1` closes the pipe after the first line, so `packer` is killed by **SIGPIPE while writing line 2 — before it restores the terminal it had switched to raw mode**. Result: the dev shell is left in `-echo` with broken readline. (qemu prints one line, so `head` never truncated it — which is why qemu alone never reproduced.)

## The fix

Use `awk 'NR==1'` instead of `head -n1`. `awk` reads to EOF (prints only line 1 but never closes the pipe early), so packer and qemu exit cleanly and restore the tty.

## Verification

Reproduced and fixed via an automated pty harness driving the real `nix develop` shell: `head -n1` → `-echo`; `awk 'NR==1'` → echo stays on. The user's `~/.bashrc`/dotfiles were proven innocent (echo broke even with them entirely removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)