### PR TITLE
Consolidate qcow images into images/ with a CACHEDIR.TAG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /*.qcow2
 /output-archlinux/
 /output-archlinux-qemu/
+# All qcow2 images live here; ignore them but keep the dir's CACHEDIR.TAG.
+/images/*.qcow2
 .vagrant
 /result
 /result-*

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 RELEASE_DATESTAMP := $(shell date +'%Y%m')
 BOX_NAME := vagrant-archlinux-test-$(RELEASE_DATESTAMP)
 
+# All qcow2 images (Packer-built base, run-qemu.sh overlays, saved snapshots)
+# live in this single directory, which carries a CACHEDIR.TAG so backups skip
+# it. Packer cannot write into an existing directory, so it still builds into
+# a temporary staging dir and build-qemu moves the artifact here.
+IMAGES_DIR := images
+
 # Optional build-time features. Pass NIX=1 to either build target to install
 # and enable Nix (with flakes) in the image, e.g. `make build-qemu NIX=1`.
 # This just maps to the Packer variable enable_nix.
@@ -11,9 +17,15 @@ endif
 build:
 	packer build -var-file isovars.pkrvars.hcl archbox.pkr.hcl
 
-# Build a bootable qcow2 disk image (no Vagrant/VirtualBox involved)
+# Build a bootable qcow2 disk image (no Vagrant/VirtualBox involved).
+# Packer builds into the staging dir output-archlinux-qemu/ (it refuses to
+# write into an existing directory), then we move the image into $(IMAGES_DIR).
 build-qemu:
+	rm -rf output-archlinux-qemu
 	packer build -var-file isovars.pkrvars.hcl archbox-qemu.pkr.hcl
+	mkdir -p $(IMAGES_DIR)
+	mv output-archlinux-qemu/*.qcow2 $(IMAGES_DIR)/
+	rm -rf output-archlinux-qemu
 
 # Boot the newest qcow2 image straight in this terminal (serial console)
 run-qemu:
@@ -22,9 +34,11 @@ run-qemu:
 clean:
 	rm -f archlinux-x64-*.box
 
+# Remove all qcow2 images (base, overlays, snapshots) but keep the CACHEDIR.TAG
+# so the directory stays marked for backup tools.
 clean-qemu:
 	rm -rf output-archlinux-qemu
-	rm -f *.overlay.qcow2
+	rm -f $(IMAGES_DIR)/*.qcow2
 
 init:
 	packer init archbox.pkr.hcl

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ image and run it directly in your terminal — no Vagrant, no libvirt, no GUI.
 
 ```sh
 make init        # once, to install the qemu Packer plugin
-make build-qemu  # produces output-archlinux-qemu/archlinux-x64-YYYYMM.qcow2
+make build-qemu  # produces images/archlinux-x64-YYYYMM.qcow2
 make run-qemu    # boots the newest image in this terminal (serial console)
 ```
 
@@ -52,9 +52,15 @@ prompt right in your shell. Log in as `vagrant` / `vagrant` (passwordless sudo
 via the `wheel` group). Press `Ctrl-a x` to quit QEMU.
 
 To keep the built image pristine, `run-qemu.sh` boots a writable qcow2 *overlay*
-backed by it (`<image>.overlay.qcow2`); all your changes land in the overlay.
-Start fresh with `RESET=1 make run-qemu`, or boot the base directly with
-`NO_OVERLAY=1 make run-qemu`. `make clean-qemu` removes the image and overlays.
+backed by it (`images/<image>.overlay.qcow2`); all your changes land in the
+overlay. Start fresh with `RESET=1 make run-qemu`, or boot the base directly
+with `NO_OVERLAY=1 make run-qemu`. `make clean-qemu` removes the images
+(keeping the `CACHEDIR.TAG`).
+
+All qcow2 images — the base, overlays, and any saved snapshots — live together
+in `images/`, which carries a [`CACHEDIR.TAG`](https://bford.info/cachedir/) so
+backup tools (`restic --exclude-caches`, `borg --exclude-caches`,
+`tar --exclude-caches`) skip these large, regenerable files.
 
 The image is built from the same provisioning scripts as the box; the QEMU build
 (`archbox-qemu.pkr.hcl`) just overrides a few `scripts/base.sh` parameters

--- a/images/CACHEDIR.TAG
+++ b/images/CACHEDIR.TAG
@@ -1,0 +1,15 @@
+Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created for vagrant-archlinux.
+#
+# It marks this directory as containing regenerable cache data so that
+# backup tools skip it. Everything here is a large qcow2 image (the Packer-built
+# base, run-qemu.sh overlays, saved provisioned snapshots) that can be rebuilt
+# with `make build-qemu`, so none of it belongs in backups.
+#
+# Honoured by e.g.:
+#   restic backup --exclude-caches
+#   borg create --exclude-caches
+#   tar --exclude-caches
+#
+# For information about cache directory tags, see:
+#   https://bford.info/cachedir/

--- a/run-qemu.sh
+++ b/run-qemu.sh
@@ -17,9 +17,10 @@
 # Usage:
 #   ./run-qemu.sh [base-image.qcow2]
 #
-# With no argument it uses the newest image in output-archlinux-qemu/ as the
-# base. Environment variables:
-#   OVERLAY=path   where to keep the writable overlay (default: ./<base>.overlay.qcow2)
+# With no argument it uses the newest base image in images/ (overlays, which
+# live in the same directory, are skipped). Environment variables:
+#   IMAGES_DIR=dir directory holding the qcow2 images (default: images)
+#   OVERLAY=path   where to keep the writable overlay (default: images/<base>.overlay.qcow2)
 #   RESET=1        discard any existing overlay and start from a fresh one
 #   NO_OVERLAY=1   boot the base image directly (writes persist into it)
 #   MEM=2048       guest memory in MB (default 8192)
@@ -36,9 +37,11 @@ set -euo pipefail
 BASE="${1:-}"
 MEM="${MEM:-8192}"
 CPUS="${CPUS:-4}"
+IMAGES_DIR="${IMAGES_DIR:-images}"
 
 if [ -z "$BASE" ]; then
-  BASE=$(ls -t output-archlinux-qemu/*.qcow2 2>/dev/null | head -n1 || true)
+  # Newest base image in IMAGES_DIR, skipping overlays (which also live here).
+  BASE=$(ls -t "$IMAGES_DIR"/*.qcow2 2>/dev/null | grep -v '\.overlay\.qcow2$' | head -n1 || true)
 fi
 
 if [ -z "$BASE" ] || [ ! -f "$BASE" ]; then
@@ -51,8 +54,10 @@ if [ -n "${NO_OVERLAY:-}" ]; then
   echo "Booting base image directly (writes persist): $DISK" >&2
 else
   # Keep the built base image pristine; boot a writable overlay backed by it.
+  # The overlay sits next to its base (in IMAGES_DIR), so the images directory
+  # holds only qcow2 files.
   BASE_ABS=$(realpath "$BASE")
-  OVERLAY="${OVERLAY:-$(basename "${BASE%.qcow2}").overlay.qcow2}"
+  OVERLAY="${OVERLAY:-${BASE%.qcow2}.overlay.qcow2}"
 
   if [ -n "${RESET:-}" ]; then
     rm -f "$OVERLAY"


### PR DESCRIPTION
## Summary

All qcow2 images now live together in a single **`images/`** directory that contains only qcow files plus a **`CACHEDIR.TAG`**. Previously images were split across two places — the Packer base in `output-archlinux-qemu/` and overlays in the repo root.

The `CACHEDIR.TAG` (standard [bford.info/cachedir](https://bford.info/cachedir/) marker, first line `Signature: 8a477f597d28d172789f06886806bc55`) lets backup tools skip this directory:

```
restic backup --exclude-caches
borg create --exclude-caches
tar --exclude-caches
```

These images (base + overlays + saved snapshots) are large and regenerable with `make build-qemu`, so they don't belong in backups.

## Changes

- **`run-qemu.sh`** — finds the newest base in `images/` (skipping overlays, which now live in the same dir via `grep -v '\.overlay\.qcow2$'`), and keeps each overlay next to its base. New `IMAGES_DIR` env var (default `images`).
- **`Makefile`** — Packer still builds into the `output-archlinux-qemu/` staging dir (it refuses to write into an existing directory, and `-force` would wipe the tag), then `build-qemu` moves the artifact into `images/`. `clean-qemu` wipes `images/*.qcow2` but keeps `CACHEDIR.TAG`.
- **`.gitignore`** — ignore `images/*.qcow2`, track `images/CACHEDIR.TAG`.
- **`README.md`** — documents the layout and the backup-exclusion behavior.

## Test plan

- `bash -n run-qemu.sh` passes; base-detection filter correctly skips overlays.
- `git check-ignore`: `images/CACHEDIR.TAG` tracked, `images/*.qcow2` ignored.
- After merge, a one-time local migration (or the next monthly `make build-qemu`) moves the existing base into `images/`:
  ```sh
  mkdir -p images && mv output-archlinux-qemu/*.qcow2 images/ && rm -rf output-archlinux-qemu
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)